### PR TITLE
added yaml.FullLoader arg to yaml.load function to avoid warning

### DIFF
--- a/kubeconfig/kubeconfig.py
+++ b/kubeconfig/kubeconfig.py
@@ -236,4 +236,4 @@ class KubeConfig(object):
             merging has been done.
         """
         conf_doc_str = self._run_kubectl_config('view')
-        return yaml.load(conf_doc_str)
+        return yaml.load(conf_doc_str, Loader=yaml.FullLoader)


### PR DESCRIPTION
I saw this warning and fixed it by updating the args for yaml.load function

```
/usr/local/lib/python3.7/site-packages/kubeconfig/kubeconfig.py:239: YAMLLoadWarning: calling yaml.load() without Loader=... is deprecated, as the default Loader is unsafe. Please read https://msg.pyyaml.org/load for full details.
  return yaml.load(conf_doc_str)
```