### PR TITLE
YAML: Use safe_load

### DIFF
--- a/kubeconfig/kubeconfig.py
+++ b/kubeconfig/kubeconfig.py
@@ -236,4 +236,4 @@ class KubeConfig(object):
             merging has been done.
         """
         conf_doc_str = self._run_kubectl_config('view')
-        return yaml.load(conf_doc_str)
+        return yaml.safe_load(conf_doc_str)

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ setup(
     author_email='greg@gctaylor.com',
     license='BSD',
     url='http://kubeconfig-python.readthedocs.io',
-    version='1.0.1',
+    version='1.0.2',
     packages=find_packages(),
     install_requires=[
         'PyYAML',


### PR DESCRIPTION
Using `yaml.load()` without a defined `Loader=...` parameter has been unsafe since inception (as it allows arbitrary code execution) and deprecated since PyYAML 5.1. Starting with PyYAML 5.1, this outputs a warning message.