### PR TITLE
view: Add --raw flag for kubectl >= 1.19

### DIFF
--- a/kubeconfig/kubeconfig.py
+++ b/kubeconfig/kubeconfig.py
@@ -244,7 +244,7 @@ class KubeConfig(object):
         args = ['view']
         version = json.loads(
             self._run(subcmd_args="version -o json --client".split())
-        )
+        )["clientVersion"]
         should_be_raw = raw and version["major"] >= 1 and version["minor"] >= 19
 
         if should_be_raw:

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ setup(
     author_email='greg@gctaylor.com',
     license='BSD',
     url='http://kubeconfig-python.readthedocs.io',
-    version='1.1.1',
+    version='1.2.0',
     packages=find_packages(),
     install_requires=[
         'PyYAML>=5.2',


### PR DESCRIPTION
Starting with kubectl 1.19, `kubectl view` returns REDACTED certificate data, and you need to pass the `--raw` flag for identical output to previous versions.
