### PR TITLE
kubeconfig/view: get unredacted config

### DIFF
--- a/kubeconfig/kubeconfig.py
+++ b/kubeconfig/kubeconfig.py
@@ -235,5 +235,5 @@ class KubeConfig(object):
         :return: A dict representing your full kubeconfig file, after all
             merging has been done.
         """
-        conf_doc_str = self._run_kubectl_config('view')
+        conf_doc_str = self._run_kubectl_config('view', '--raw')
         return yaml.safe_load(conf_doc_str)

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ setup(
     author_email='greg@gctaylor.com',
     license='BSD',
     url='http://kubeconfig-python.readthedocs.io',
-    version='1.1.1',
+    version='1.1.2',
     packages=find_packages(),
     install_requires=[
         'PyYAML>=5.2',


### PR DESCRIPTION
More recent releases of kubectl redact out sensitive information such as user token. We want the real thing though and request raw content.

Confirmed with previous versions of kubectl (back to 1.1.0) that they support the parameter.